### PR TITLE
bump ubuntu to 20.04 and node to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,18 @@ USER root
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && \
-    apt install -y git procmail curl gnupg2 apt-transport-https \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    git \
+    procmail \
+    curl \
+    gnupg2 \
+    apt-transport-https \
     ca-certificates \
     curl \
     gnupg-agent \
-    software-properties-common
+    software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
@@ -22,8 +28,15 @@ RUN add-apt-repository \
     "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
     $(lsb_release -cs) \
     stable" && \
-    apt update && \
-    apt install -y nodejs yarn docker-ce docker-ce-cli containerd.io
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    nodejs \
+    yarn \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    && rm -rf /var/lib/apt/lists/*
+
 
 RUN git clone https://github.com/FredTingaud/quick-bench-back-end /quick-bench && \
     cd /quick-bench && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Fred Tingaud <ftingaud@hotmail.com>"
 
@@ -15,13 +15,13 @@ RUN apt update && \
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 
 RUN add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-      $(lsb_release -cs) \
-      stable" && \
+    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) \
+    stable" && \
     apt update && \
     apt install -y nodejs yarn docker-ce docker-ce-cli containerd.io
 


### PR DESCRIPTION
This is like https://github.com/FredTingaud/bench-runner/pull/3 but without the changes to `quick-bench` and `build-bench`.
Node was bumped and the overall size of the image was slightly reduced by cleaning the apt cache.