### PR TITLE
Script to create a container on windows

### DIFF
--- a/Create-Container.ps1
+++ b/Create-Container.ps1
@@ -1,0 +1,15 @@
+$lines=(docker container ls --all -f "name=c_quick_bench")
+
+$ok_msg="You can run the container: docker start c_quick_bench"
+
+if($lines.Length -eq 2) {
+    Write-Host $ok_msg
+} else {
+    Write-Host "Creating c_quick_bench"
+    docker create -v "$(pwd)/data:/data" -v "//var/run/docker.sock:/var/run/docker.sock" --env-file "$(pwd)\local.env" -e "BENCH_ROOT=$(pwd)" -p 4000:4000 --name c_quick_bench -it fredtingaud/bench-runner ./start-quick-bench
+    if($?) {
+        Write-Host $ok_msg
+    } else {
+        Write-Host "Could not create container."
+    }
+}

--- a/build-bench
+++ b/build-bench
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 4000:4000 -v $PWD/data:/data -v /var/run/docker.sock:/var/run/docker.sock --env-file local.env -e BENCH_ROOT=$PWD -it fredtingaud/bench-runner ./start-build-bench
+docker run --rm -p 4000:4000 -v $PWD/data:/data -v /var/run/docker.sock:/var/run/docker.sock --env-file local.env -e BENCH_ROOT=$PWD -it fredtingaud/bench-runner ./start-build-bench

--- a/quick-bench
+++ b/quick-bench
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run -p 4000:4000 -v $PWD/data:/data -v /var/run/docker.sock:/var/run/docker.sock --env-file local.env -e BENCH_ROOT=$PWD -it fredtingaud/bench-runner ./start-quick-bench
+docker run --rm -p 4000:4000 -v $PWD/data:/data -v /var/run/docker.sock:/var/run/docker.sock --env-file local.env -e BENCH_ROOT=$PWD -it fredtingaud/bench-runner ./start-quick-bench


### PR DESCRIPTION
Windows have some differences on mapping things (like docker.sock).

I think windows people like to manage the containers in the gui, so create one container and starting and stoping it from there is much more "windows like".